### PR TITLE
Fixes to documentation

### DIFF
--- a/environments/development.yml
+++ b/environments/development.yml
@@ -52,3 +52,4 @@ dependencies:
   - xlsxwriter
   - xmle >=0.1.3
   - zarr
+  - xgboost


### PR DESCRIPTION
There seems to be a missing requirement, which breaks documentation.

https://larch.newman.me/v5.7.0/user-guide/machine-learning.html

Evidence of requirement
https://github.com/jpn--/larch/blob/master/larch/prelearning.py